### PR TITLE
fix(shellui): inject dynamic plugin toggle value on page creation

### DIFF
--- a/source/shellui/include/dynamic_ui_runtime.hpp
+++ b/source/shellui/include/dynamic_ui_runtime.hpp
@@ -48,6 +48,9 @@ void append_plugin_links(
 bool render_resource(std::string_view resource, std::string &out_xml);
 DispatchResult dispatch_control(std::string_view control_id,
                                 std::string_view value);
+/** Resolve the current value of the active page's control by its XML id. */
+bool resolve_control_value(std::string_view xml_control_id,
+                           std::string &out_value);
 /* Returns true when another page from the same dynamic stack becomes active. */
 bool leave_active_page();
 

--- a/source/shellui/include/shellui_state.hpp
+++ b/source/shellui/include/shellui_state.hpp
@@ -12,6 +12,8 @@
 #include <string_view>
 #include <vector>
 
+#include <onion/ipc_client.hpp>
+
 /** Settings page / resource-stream context for ShellUI hooks. */
 struct ToolboxUiState {
   toolbox::Page active_page = toolbox::Page::None;
@@ -33,6 +35,8 @@ struct ToolboxUiState {
   std::vector<PayloadEntry> auto_payloads_list;
   std::vector<Payloads_Apps> payloads_apps_list;
   std::vector<GameEntry> games_list;
+
+  std::vector<PluginInventoryItem> external_plugins;
 
   /* The plugin whose config page is active; a registry key ("kstuff"/…). */
   std::string active_plugin;

--- a/source/shellui/src/dynamic_ui_runtime.cpp
+++ b/source/shellui/src/dynamic_ui_runtime.cpp
@@ -133,6 +133,29 @@ bool render_resource(std::string_view resource, std::string &out_xml) {
   return true;
 }
 
+bool resolve_control_value(std::string_view xml_control_id,
+                           std::string &out_value) {
+  RuntimeState &runtime = state();
+  std::lock_guard<std::mutex> lock(runtime.mutex);
+  if (runtime.page_stack.empty() ||
+      !runtime.page_stack.back().contribution.document)
+    return false;
+  const RuntimeState::ActivePage &page = runtime.page_stack.back();
+  const plugin_ui::Node *node =
+      resolve_control(*page.contribution.document, page.page_id, xml_control_id);
+  if (!node || !interactive(*node)) return false;
+  if (node->kind == plugin_ui::NodeKind::Toggle) {
+    out_value = (node->value == "1" || node->value == "true") ? "1" : "0";
+    return true;
+  }
+  if (node->kind == plugin_ui::NodeKind::List ||
+      node->kind == plugin_ui::NodeKind::Input) {
+    out_value = node->value;
+    return true;
+  }
+  return false;
+}
+
 DispatchResult dispatch_control(std::string_view control_id_value,
                                 std::string_view value) {
   plugin_ui::ContributionSnapshot active;

--- a/source/shellui/src/external_plugin_ui.cpp
+++ b/source/shellui/src/external_plugin_ui.cpp
@@ -1,5 +1,6 @@
 #include "external_plugin_ui.hpp"
 
+#include "shellui_state.hpp"
 #include "toolbox_i18n.hpp"
 #include "dynamic_ui_runtime.hpp"
 
@@ -34,6 +35,11 @@ std::vector<std::string> append_inventory(
   std::vector<std::string> matched;
   std::vector<PluginInventoryItem> plugins;
   const bool loaded = IPC_Client::getInstance(false).ListPlugins(plugins);
+  if (loaded) {
+    g_ui.external_plugins = plugins;
+  } else {
+    g_ui.external_plugins.clear();
+  }
   if (loaded && plugins.empty()) return matched;
 
   page.group(

--- a/source/shellui/src/toolbox_values.cpp
+++ b/source/shellui/src/toolbox_values.cpp
@@ -9,6 +9,7 @@
 #include "shellui_payload_state.hpp"
 #include "shellui_state.hpp"
 #include "toolbox_i18n.hpp"
+#include "dynamic_ui_runtime.hpp"
 
 #include <onion/platform.h>
 #include <onion/ipc_client.hpp>
@@ -133,6 +134,36 @@ bool try_cheat_value(const std::string &id, std::string &out) {
   return true;
 }
 
+constexpr std::string_view kRunPrefix = "id_external_plugin_run_";
+constexpr std::string_view kAutoStartPrefix = "id_external_plugin_autostart_";
+
+bool try_external_plugin_value(const std::string &id, std::string &out) {
+  const std::string_view sv(id);
+  std::string_view prefix;
+  bool is_run = false;
+  if (sv.starts_with(kRunPrefix)) {
+    prefix = kRunPrefix;
+    is_run = true;
+  } else if (sv.starts_with(kAutoStartPrefix)) {
+    prefix = kAutoStartPrefix;
+  } else {
+    return false;
+  }
+  const std::string_view suffix = sv.substr(prefix.size());
+  if (suffix.size() != 9) return false;
+  const std::string plugin_id(suffix);
+  for (const auto &plugin : g_ui.external_plugins) {
+    if (plugin.plugin_id != plugin_id) continue;
+    out = bool_str(is_run ? plugin.running : plugin.auto_start);
+    return true;
+  }
+  return false;
+}
+
+bool try_dynamic_control_value(const std::string &id, std::string &out) {
+  return onion::shellui::dynamic_ui::resolve_control_value(id, out);
+}
+
 } // namespace
 
 std::string resolve_toolbox_control_value(const std::string &id) {
@@ -145,6 +176,10 @@ std::string resolve_toolbox_control_value(const std::string &id) {
   if (try_exact_value(id, value))
     return value;
   if (try_cheat_value(id, value))
+    return value;
+  if (try_external_plugin_value(id, value))
+    return value;
+  if (try_dynamic_control_value(id, value))
     return value;
 
   return {};


### PR DESCRIPTION
# fix(shellui): inject dynamic plugin toggle value on page creation

OnionHEN's generated pages bind toggle values during SettingPage.OnCreating (OnPreCreate_Hook -> resolve_toolbox_control_value -> set_Value) because the legacy PS5 settings framework does not honor the XML 'value' attribute.

Dynamic plugin config pages and external plugin list toggles had no such resolver, so a toggle reverted to its default OFF state on page re-entry even when the plugin/setting was actually active.

Add a resolver that reads the live node value from the dynamic UI runtime snapshot and injects it through the existing OnPreCreate binding path.

## What

Adds `resolve_control_value()` to the dynamic UI runtime, which reads the live value of the active page's control (Toggle -> "1"/"0", List/Input -> its value) from the runtime snapshot. Two new resolvers in `toolbox_values.cpp` wire this and the external plugin run/autostart state into the existing OnPreCreate value-binding path, and the plugin inventory is cached in `g_ui` so the list toggles reflect real running/autostart state.

## Why

Generated plugin pages (dynamic config pages and the external Plugins list) had no value resolver, so their toggles and inputs fell back to the framework's default (OFF/empty) on page re-entry, even when the plugin/setting was actually active. This makes re-entering a plugin config page show the true persisted state instead of a stale default.

## Checklist

- [x] Change stays on this request
- [x] `make -C source/util/tests test` passes
- [ ] `docs/arch.md` updated if modules, IPC, paths, or dependencies changed
- [ ] i18n keys updated in every locale if user-facing text changed
